### PR TITLE
isKernelDeviceActive not supported on Windows

### DIFF
--- a/lib/event-handlers/keyboard.js
+++ b/lib/event-handlers/keyboard.js
@@ -11,7 +11,7 @@ function KeyboardEvent() {
   }
 }
 
-KeyboardEvent.emptyDataBuffer = new Buffer(8).fill(0);
+KeyboardEvent.emptyDataBuffer = Buffer.alloc(8, 0);
 
 KeyboardEvent.prototype.isEmpty = function () {
   return !this.data.compare(KeyboardEvent.emptyDataBuffer);

--- a/lib/event-handlers/numpad.js
+++ b/lib/event-handlers/numpad.js
@@ -11,7 +11,7 @@ function NumpadEvent() {
   }
 }
 
-NumpadEvent.emptyDataBuffer = new Buffer(8).fill(0);
+NumpadEvent.emptyDataBuffer = Buffer.alloc(8, 0);
 
 NumpadEvent.prototype.isEmpty = function () {
   return !this.data.compare(NumpadEvent.emptyDataBuffer);

--- a/lib/hid-handler.js
+++ b/lib/hid-handler.js
@@ -211,7 +211,7 @@ that = _.extend(new events.EventEmitter(), {
             return;
           }
           logger.enabledLevels.trace && log.trace('found device interface #%s of type %s :', ifaceIndex, opt.device.type[ifaceIndex], util.logObject(iface));
-          if (iface.isKernelDriverActive()) {
+          if (process.platform !== "win32" && iface.isKernelDriverActive()) {
             logger.enabledLevels.debug && log.debug('detach interface #%s of device "%s" from kernel', ifaceIndex, hid.deviceKey);
             iface.detachKernelDriver();
           }
@@ -290,7 +290,7 @@ that = _.extend(new events.EventEmitter(), {
               return p.fromNode(iface.release.bind(iface, true))
                 .then(function () {
                   logger.enabledLevels.debug && log.debug('interface #%s released for device "%s"', ifaceIndex, hid.deviceKey);
-                  if (!iface.isKernelDriverActive()) {
+                  if (process.platform !== "win32" && !iface.isKernelDriverActive()) {
                     logger.enabledLevels.debug && log.debug('reattach interface #%s of device "%s" from kernel', ifaceIndex, hid.deviceKey);
                     iface.attachKernelDriver();
                   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hw-promise": "0.0.2",
     "jsonic": "^0.2.2",
     "lodash": "^3.10.1",
-    "node-hid": "^0.5.1",
+    "node-hid": "^0.7.6",
     "properties": "^1.2.1",
     "require-directory": "^2.1.1",
     "usb": "^1.1.1",


### PR DESCRIPTION
Only calling `isKernelDeviceActive` if `process.platform !== "win32"`